### PR TITLE
Refactor about screen

### DIFF
--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
@@ -1,6 +1,5 @@
 package com.byagowi.persiancalendar.ui.about
 
-import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri
@@ -8,7 +7,12 @@ import android.os.Build
 import android.os.Bundle
 import android.text.util.Linkify
 import android.util.TypedValue
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
@@ -19,18 +23,35 @@ import androidx.core.net.toUri
 import androidx.core.view.setMargins
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
-import com.byagowi.persiancalendar.*
+import com.byagowi.persiancalendar.BuildConfig
+import com.byagowi.persiancalendar.LANG_AZB
+import com.byagowi.persiancalendar.LANG_EN_IR
+import com.byagowi.persiancalendar.LANG_FA
+import com.byagowi.persiancalendar.LANG_FA_AF
+import com.byagowi.persiancalendar.LANG_GLK
+import com.byagowi.persiancalendar.R
 import com.byagowi.persiancalendar.databinding.DialogEmailBinding
 import com.byagowi.persiancalendar.databinding.FragmentAboutBinding
 import com.byagowi.persiancalendar.ui.MainActivity
-import com.byagowi.persiancalendar.utils.*
+import com.byagowi.persiancalendar.utils.bringMarketPage
+import com.byagowi.persiancalendar.utils.formatNumber
+import com.byagowi.persiancalendar.utils.language
+import com.byagowi.persiancalendar.utils.logException
+import com.byagowi.persiancalendar.utils.readRawResource
+import com.byagowi.persiancalendar.utils.supportedYearOfIranCalendar
 import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
 
 class AboutFragment : Fragment() {
 
+    private val appVersionList
+        get() = BuildConfig.VERSION_NAME.split("-")
+            .mapIndexed { i, x -> if (i == 0) formatNumber(x) else x }
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
     ): View {
         val mainActivity = activity as MainActivity
         mainActivity.setTitleAndSubtitle(getString(R.string.about), "")
@@ -39,10 +60,7 @@ class AboutFragment : Fragment() {
         val binding = FragmentAboutBinding.inflate(inflater, container, false)
 
         // version
-        val version = programVersion(mainActivity).split("-")
-            .mapIndexed { i, x -> if (i == 0) formatNumber(x) else x }
-        binding.version.text =
-            getString(R.string.version).format(version.joinToString("\n"))
+        binding.version.text = getString(R.string.version).format(appVersionList.joinToString("\n"))
 
         // licenses
         binding.licenses.setOnClickListener {
@@ -112,7 +130,7 @@ class AboutFragment : Fragment() {
 Manufacturer: ${Build.MANUFACTURER}
 Model: ${Build.MODEL}
 Android Version: ${Build.VERSION.RELEASE}
-App Version Code: ${version[0]}"""
+App Version Code: ${appVersionList[0]}"""
                         )
                         startActivity(
                             Intent.createChooser(
@@ -234,8 +252,4 @@ App Version Code: ${version[0]}"""
         }
         return true
     }
-
-    private fun programVersion(context: Context): String = runCatching {
-        context.packageManager.getPackageInfo(context.packageName, 0).versionName
-    }.onFailure(logException).getOrDefault("")
 }

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
@@ -13,14 +13,12 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
-import androidx.core.view.setMargins
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
 import com.byagowi.persiancalendar.BuildConfig
@@ -91,14 +89,9 @@ class AboutFragment : Fragment() {
         val developerIcon = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_developer)
         val translatorIcon = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_translator)
         val designerIcon = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_designer)
-        val chipsIconsColor = TypedValue().apply {
+        val chipsIconTintId = TypedValue().apply {
             requireContext().theme.resolveAttribute(R.attr.colorDrawerIcon, this, true)
         }.resourceId
-
-        val chipsLayoutParams = LinearLayout.LayoutParams(
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT
-        ).apply { setMargins(8) }
 
         val chipClick = View.OnClickListener {
             (it.tag as? String?)?.run {
@@ -113,13 +106,12 @@ class AboutFragment : Fragment() {
         getString(R.string.about_developers_list)
             .trim().split("\n").shuffled().map {
                 Chip(context).apply {
-                    layoutParams = chipsLayoutParams
                     setOnClickListener(chipClick)
                     val parts = it.split(": ")
                     tag = parts[0]
                     text = parts[1]
                     chipIcon = developerIcon
-                    setChipIconTintResource(chipsIconsColor)
+                    setChipIconTintResource(chipsIconTintId)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                         elevation = resources.getDimension(R.dimen.chip_elevation)
                     }
@@ -129,39 +121,36 @@ class AboutFragment : Fragment() {
         getString(R.string.about_designers_list)
             .trim().split("\n").shuffled().map {
                 Chip(context).apply {
-                    layoutParams = chipsLayoutParams
                     // setOnClickListener(chipClick)
                     val parts = it.split(": ")
                     if (parts.size == 2) tag = parts[0]
                     text = parts.last()
                     chipIcon = designerIcon
-                    setChipIconTintResource(chipsIconsColor)
+                    setChipIconTintResource(chipsIconTintId)
                 }
             }.forEach(binding.developers::addView)
 
         getString(R.string.about_translators_list)
             .trim().split("\n").shuffled().map {
                 Chip(context).apply {
-                    layoutParams = chipsLayoutParams
                     setOnClickListener(chipClick)
                     val parts = it.split(": ")
                     tag = parts[0]
                     text = parts[1]
                     chipIcon = translatorIcon
-                    setChipIconTintResource(chipsIconsColor)
+                    setChipIconTintResource(chipsIconTintId)
                 }
             }.forEach(binding.developers::addView)
 
         getString(R.string.about_contributors_list)
             .trim().split("\n").shuffled().map {
                 Chip(context).apply {
-                    layoutParams = chipsLayoutParams
                     setOnClickListener(chipClick)
                     val parts = it.split(": ")
                     tag = parts[0]
                     text = parts[1]
                     chipIcon = developerIcon
-                    setChipIconTintResource(chipsIconsColor)
+                    setChipIconTintResource(chipsIconTintId)
                 }
             }.forEach(binding.developers::addView)
     }

--- a/PersianCalendar/src/main/res/layout/fragment_about.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_about.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -146,7 +147,8 @@
                         android:layout_height="wrap_content"
                         android:text="@string/about_help_sum"
                         android:textColor="?attr/colorTextSecond"
-                        android:textSize="12sp" />
+                        android:textSize="12sp"
+                        tools:text="short summery" />
 
                 </LinearLayout>
 
@@ -262,15 +264,13 @@
                 android:text="@string/about_developers"
                 android:textColor="?attr/colorTextDrawer" />
 
-            <LinearLayout
+            <com.google.android.material.chip.ChipGroup
                 android:id="@+id/developers"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="?android:attr/selectableItemBackground"
                 android:layoutDirection="ltr"
                 android:orientation="vertical"
-                android:padding="5dp"
-                android:textColor="?attr/colorTextDrawer" />
+                android:padding="5dp" />
 
         </LinearLayout>
 


### PR DESCRIPTION
- Decrease dependencies to MainActivity and replace it with fragment's context
- Reuse BuildConfig's version name instead of fetching from PackageManager
- Break down the long onCreateView method of AboutFragment into small methods
- Use ChipGroup for contributors box (change linear to cloud-word items)