### PR TITLE
Separate all fragments toolbar

### DIFF
--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/MainActivity.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/MainActivity.kt
@@ -13,7 +13,6 @@ import androidx.activity.addCallback
 import androidx.annotation.IdRes
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
@@ -39,9 +38,6 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     private var creationDateJdn: Long = 0
     private var settingHasChanged = false
     private lateinit var binding: ActivityMainBinding
-
-    val coordinator: CoordinatorLayout
-        get() = binding.coordinator
 
     private var clickedItem = 0
 
@@ -79,7 +75,6 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         binding = ActivityMainBinding.inflate(layoutInflater).also {
             setContentView(it.root)
         }
-        setSupportActionBar(binding.toolbar)
 
         obtainNavHost() // sake of initialize NavHost
 
@@ -145,22 +140,17 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
         when {
             appPrefs.getString(PREF_APP_LANGUAGE, null) == null &&
-                    !appPrefs.getBoolean(CHANGE_LANGUAGE_IS_PROMOTED_ONCE, false) -> {
+                !appPrefs.getBoolean(CHANGE_LANGUAGE_IS_PROMOTED_ONCE, false) -> {
                 changeLangSnackbar().show()
                 appPrefs.edit { putBoolean(CHANGE_LANGUAGE_IS_PROMOTED_ONCE, true) }
             }
-        }
-
-        when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> binding.appbarLayout.outlineProvider =
-                null
         }
 
         creationDateJdn = getTodayJdn()
 
         when {
             mainCalendar == CalendarType.SHAMSI && isIranHolidaysEnabled &&
-                    getTodayOfCalendar(CalendarType.SHAMSI).year > supportedYearOfIranCalendar -> outDatedSnackbar().show()
+                getTodayOfCalendar(CalendarType.SHAMSI).year > supportedYearOfIranCalendar -> outDatedSnackbar().show()
         }
 
         applyAppLanguage(this)
@@ -273,7 +263,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
                             when {
                                 currentHolidays.isEmpty() || currentHolidays.size == 1 &&
-                                        "iran_holidays" in currentHolidays -> putStringSet(
+                                    "iran_holidays" in currentHolidays -> putStringSet(
                                     PREF_HOLIDAY_TYPES,
                                     setOf("afghanistan_holidays")
                                 )
@@ -320,8 +310,8 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
         when {
             key == PREF_SHOW_DEVICE_CALENDAR_EVENTS &&
-                    sharedPreferences?.getBoolean(PREF_SHOW_DEVICE_CALENDAR_EVENTS, true) == true
-                    && ActivityCompat.checkSelfPermission(
+                sharedPreferences?.getBoolean(PREF_SHOW_DEVICE_CALENDAR_EVENTS, true) == true
+                && ActivityCompat.checkSelfPermission(
                 this, Manifest.permission.READ_CALENDAR
             ) != PackageManager.PERMISSION_GRANTED -> askForCalendarPermission(this)
         }
@@ -332,7 +322,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
         when {
             key == PREF_NOTIFY_DATE &&
-                    sharedPreferences?.getBoolean(PREF_NOTIFY_DATE, true) == false -> {
+                sharedPreferences?.getBoolean(PREF_NOTIFY_DATE, true) == false -> {
                 stopService(Intent(this, ApplicationService::class.java))
                 startEitherServiceOrWorker(applicationContext)
             }
@@ -430,7 +420,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     }
 
     private fun changeLangSnackbar() =
-        Snackbar.make(coordinator, "✖  Change app language?", 7000).apply {
+        Snackbar.make(binding.root, "✖  Change app language?", 7000).apply {
             view.layoutDirection = View.LAYOUT_DIRECTION_LTR
             view.setOnClickListener { dismiss() }
             setAction("Settings") {
@@ -442,7 +432,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         }
 
     private fun outDatedSnackbar() =
-        Snackbar.make(coordinator, getString(R.string.outdated_app), 10000).apply {
+        Snackbar.make(binding.root, getString(R.string.outdated_app), 10000).apply {
             setAction(getString(R.string.update)) {
                 bringMarketPage(this@MainActivity)
             }
@@ -450,7 +440,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         }
 
     private fun drawerToggle() = object : ActionBarDrawerToggle(
-        this, binding.drawer, binding.toolbar, R.string.openDrawer, R.string.closeDrawer
+        this, binding.drawer, null, R.string.openDrawer, R.string.closeDrawer
     ) {
         val slidingDirection = when {
             isRTL(this@MainActivity) -> -1
@@ -463,7 +453,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         }
 
         private fun slidingAnimation(drawerView: View, slideOffset: Float) = binding.apply {
-            appMainLayout.translationX =
+            navHostContainer.translationX =
                 slideOffset * drawerView.width.toFloat() * slidingDirection.toFloat()
             drawer.bringChildToFront(drawerView)
             drawer.requestLayout()

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/MainActivity.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/MainActivity.kt
@@ -24,6 +24,7 @@ import com.byagowi.persiancalendar.*
 import com.byagowi.persiancalendar.databinding.ActivityMainBinding
 import com.byagowi.persiancalendar.databinding.NavigationHeaderBinding
 import com.byagowi.persiancalendar.service.ApplicationService
+import com.byagowi.persiancalendar.ui.calendar.CalendarNavIconListener
 import com.byagowi.persiancalendar.utils.*
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
@@ -32,6 +33,7 @@ import com.google.android.material.snackbar.Snackbar
  * Program activity for android
  */
 class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceChangeListener,
+    CalendarNavIconListener,
     NavigationView.OnNavigationItemSelectedListener {
 
     private var creationDateJdn: Long = 0
@@ -427,12 +429,6 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         return true
     }
 
-    fun setTitleAndSubtitle(title: String, subtitle: String): Unit = supportActionBar?.let {
-        it.title = title
-        it.subtitle = subtitle
-    } ?: Unit
-
-
     private fun changeLangSnackbar() =
         Snackbar.make(coordinator, "✖  Change app language?", 7000).apply {
             view.layoutDirection = View.LAYOUT_DIRECTION_LTR
@@ -480,5 +476,9 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                 clickedItem = 0
             }
         }
+    }
+
+    override fun onBurgerMenuClicked() {
+        binding.drawer.openDrawer(GravityCompat.START)
     }
 }

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
@@ -41,6 +41,7 @@ class AboutFragment : Fragment() {
 
         with(binding.appBar.toolbar) {
             setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationContentDescription(R.string.navigate_back_button_label)
             setNavigationOnClickListener { findNavController().navigateUp() }
             setTitle(R.string.about)
             inflateMenu(R.menu.about_menu_buttons)

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/AboutFragment.kt
@@ -7,7 +7,9 @@ import android.os.Build
 import android.os.Bundle
 import android.text.util.Linkify
 import android.util.TypedValue
-import android.view.*
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
@@ -16,11 +18,10 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
+import androidx.navigation.findNavController
 import com.byagowi.persiancalendar.*
 import com.byagowi.persiancalendar.databinding.DialogEmailBinding
 import com.byagowi.persiancalendar.databinding.FragmentAboutBinding
-import com.byagowi.persiancalendar.ui.MainActivity
 import com.byagowi.persiancalendar.utils.*
 import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
@@ -36,11 +37,23 @@ class AboutFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val mainActivity = activity as MainActivity
-        mainActivity.setTitleAndSubtitle(getString(R.string.about), "")
-        setHasOptionsMenu(true)
-
         val binding = FragmentAboutBinding.inflate(inflater, container, false)
+
+        with(binding.appBar.toolbar) {
+            setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationOnClickListener { findNavController().navigateUp() }
+            setTitle(R.string.about)
+            inflateMenu(R.menu.about_menu_buttons)
+            setOnMenuItemClickListener { menuItem ->
+                when (menuItem.itemId) {
+                    R.id.deviceInformation ->
+                        findNavController().navigate(AboutFragmentDirections.actionAboutToDeviceinfo())
+                    R.id.share ->
+                        shareApplication()
+                }
+                true
+            }
+        }
 
         // version
         binding.version.text = getString(R.string.version).format(appVersionList.joinToString("\n"))
@@ -219,12 +232,6 @@ App Version Code: ${appVersionList[0]}"""
             }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        menu.clear()
-        inflater.inflate(R.menu.about_menu_buttons, menu)
-    }
-
     private fun shareApplication() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
             runCatching {
@@ -239,13 +246,5 @@ App Version Code: ${appVersionList[0]}"""
             }
                 .onFailure(logException)
                 .getOrElse { bringMarketPage(activity ?: return) }
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-            R.id.deviceInformation -> findNavController().navigate(AboutFragmentDirections.actionAboutToDeviceinfo())
-            R.id.share -> shareApplication()
-        }
-        return true
     }
 }

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/DeviceInformationFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/DeviceInformationFragment.kt
@@ -29,6 +29,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.*
 import com.byagowi.persiancalendar.R
 import com.byagowi.persiancalendar.databinding.DeviceInformationRowBinding
@@ -56,7 +57,11 @@ class DeviceInformationFragment : Fragment() {
     ) = FragmentDeviceInfoBinding.inflate(inflater, container, false).also { binding ->
         val mainActivity = activity as MainActivity
 
-        mainActivity.setTitleAndSubtitle(getString(R.string.device_info), "")
+        with(binding.appBar.toolbar) {
+            setTitle(R.string.device_info)
+            setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationOnClickListener { findNavController().navigateUp() }
+        }
 
         circularRevealFromMiddle(binding.circularReveal)
 

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/DeviceInformationFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/about/DeviceInformationFragment.kt
@@ -60,6 +60,7 @@ class DeviceInformationFragment : Fragment() {
         with(binding.appBar.toolbar) {
             setTitle(R.string.device_info)
             setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationContentDescription(R.string.navigate_back_button_label)
             setNavigationOnClickListener { findNavController().navigateUp() }
         }
 

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/calendar/CalendarFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/calendar/CalendarFragment.kt
@@ -195,6 +195,7 @@ class CalendarFragment : Fragment(),
 
         mainBinding?.appBar?.let { appbar ->
             appbar.toolbar.setNavigationIcon(R.drawable.ic_burger_menu)
+            appbar.toolbar.setNavigationContentDescription(R.string.menu_button_label)
             appbar.toolbar.setNavigationOnClickListener { navIconListener?.onBurgerMenuClicked() }
             appbar.toolbar.inflateMenu(R.menu.calendar_menu_buttons)
             setupToolbarMenu(appbar.toolbar.menu)

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/calendar/CalendarFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/calendar/CalendarFragment.kt
@@ -21,7 +21,6 @@ import android.widget.ArrayAdapter
 import androidx.activity.addCallback
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.SearchAutoComplete
-import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
@@ -55,8 +54,7 @@ private const val CALENDARS_TAB = 0
 private const val EVENTS_TAB = 1
 private const val OWGHAT_TAB = 2
 
-class CalendarFragment : Fragment(),
-    Toolbar.OnMenuItemClickListener {
+class CalendarFragment : Fragment() {
 
     private var coordinate: Coordinate? = null
     private var mainBinding: FragmentCalendarBinding? = null
@@ -199,7 +197,15 @@ class CalendarFragment : Fragment(),
             appbar.toolbar.setNavigationOnClickListener { navIconListener?.onBurgerMenuClicked() }
             appbar.toolbar.inflateMenu(R.menu.calendar_menu_buttons)
             setupToolbarMenu(appbar.toolbar.menu)
-            appbar.toolbar.setOnMenuItemClickListener(this)
+            appbar.toolbar.setOnMenuItemClickListener { item ->
+                when (item?.itemId) {
+                    R.id.go_to -> openGoToDayDialog()
+                    R.id.add_event -> addEventOnCalendar(selectedJdn)
+                    R.id.shift_work -> openShiftWorkDialog()
+                    R.id.month_overview -> openMonthOverView()
+                }
+                true
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) appbar.appbarLayout.outlineProvider = null
         }
 
@@ -523,29 +529,31 @@ class CalendarFragment : Fragment(),
         }
     }
 
-    override fun onMenuItemClick(item: MenuItem?): Boolean {
-        when (item?.itemId) {
-            R.id.go_to -> SelectDayDialog.newInstance(selectedJdn).apply {
-                onSuccess = fun(jdn: Long) { bringDate(jdn) }
-            }.show(
-                childFragmentManager,
-                SelectDayDialog::class.java.name
-            )
-            R.id.add_event -> addEventOnCalendar(selectedJdn)
-            R.id.shift_work -> ShiftWorkDialog.newInstance(selectedJdn).apply {
-                onSuccess = fun() {
-                    updateStoredPreference(mainActivity)
-                    mainActivity.restartActivity()
-                }
-            }.show(
-                childFragmentManager,
-                ShiftWorkDialog::class.java.name
-            )
-            R.id.month_overview -> MonthOverviewDialog
-                .newInstance(mainBinding?.calendarPager?.selectedMonth?.toJdn() ?: getTodayJdn())
-                .show(childFragmentManager, MonthOverviewDialog::class.java.name)
-        }
-        return true
+    private fun openGoToDayDialog() {
+        SelectDayDialog.newInstance(selectedJdn).apply {
+            onSuccess = fun(jdn: Long) { bringDate(jdn) }
+        }.show(
+            childFragmentManager,
+            SelectDayDialog::class.java.name
+        )
+    }
+
+    private fun openShiftWorkDialog() {
+        ShiftWorkDialog.newInstance(selectedJdn).apply {
+            onSuccess = fun() {
+                updateStoredPreference(mainActivity)
+                mainActivity.restartActivity()
+            }
+        }.show(
+            childFragmentManager,
+            ShiftWorkDialog::class.java.name
+        )
+    }
+
+    private fun openMonthOverView() {
+        MonthOverviewDialog
+            .newInstance(mainBinding?.calendarPager?.selectedMonth?.toJdn() ?: getTodayJdn())
+            .show(childFragmentManager, MonthOverviewDialog::class.java.name)
     }
 
     /**

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/calendar/CalendarNavIconListener.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/calendar/CalendarNavIconListener.kt
@@ -1,0 +1,5 @@
+package com.byagowi.persiancalendar.ui.calendar
+
+interface CalendarNavIconListener {
+    fun onBurgerMenuClicked()
+}

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/compass/CompassFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/compass/CompassFragment.kt
@@ -102,6 +102,7 @@ class CompassFragment : Fragment() {
                 setTitle(R.string.compass)
                 subtitle = getCityName(mainActivity, true)
                 setNavigationIcon(R.drawable.ic_arrow_back)
+                setNavigationContentDescription(R.string.navigate_back_button_label)
                 setNavigationOnClickListener { findNavController().navigateUp() }
             }
 

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/compass/CompassFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/compass/CompassFragment.kt
@@ -78,12 +78,14 @@ class CompassFragment : Fragment() {
         }
     }
 
-    private fun showLongSnackbar(@StringRes messageId: Int, duration: Int) =
-        Snackbar.make(mainActivity.coordinator, messageId, duration).apply {
+    private fun showLongSnackbar(@StringRes messageId: Int, duration: Int) {
+        val rootView = view ?: return
+        Snackbar.make(rootView, messageId, duration).apply {
             view.setOnClickListener { dismiss() }
             view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text).maxLines = 5
-        }.setAnchorView(binding?.fab)
-            .show()
+            anchorView = binding?.fab
+        }.show()
+    }
 
     private lateinit var mainActivity: MainActivity
 

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/compass/CompassFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/compass/CompassFragment.kt
@@ -14,6 +14,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import com.byagowi.persiancalendar.R
 import com.byagowi.persiancalendar.databinding.FragmentCompassBinding
@@ -97,10 +98,12 @@ class CompassFragment : Fragment() {
         val binding = FragmentCompassBinding.inflate(inflater, container, false).apply {
             coordinate = getCoordinate(mainActivity)
 
-            mainActivity.setTitleAndSubtitle(
-                getString(R.string.compass),
-                getCityName(mainActivity, true)
-            )
+            with(appBar.toolbar) {
+                setTitle(R.string.compass)
+                subtitle = getCityName(mainActivity, true)
+                setNavigationIcon(R.drawable.ic_arrow_back)
+                setNavigationOnClickListener { findNavController().navigateUp() }
+            }
 
             bottomAppbar.replaceMenu(R.menu.compass_menu_buttons)
             bottomAppbar.setOnMenuItemClickListener { item ->

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/converter/ConverterFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/converter/ConverterFragment.kt
@@ -19,6 +19,7 @@ class ConverterFragment : Fragment() {
     ) = FragmentConverterBinding.inflate(inflater, container, false).apply {
         with(appBar.toolbar) {
             setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationContentDescription(R.string.navigate_back_button_label)
             setNavigationOnClickListener { findNavController().navigateUp() }
             setTitle(R.string.date_converter)
         }

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/converter/ConverterFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/converter/ConverterFragment.kt
@@ -5,9 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.findNavController
 import com.byagowi.persiancalendar.R
 import com.byagowi.persiancalendar.databinding.FragmentConverterBinding
-import com.byagowi.persiancalendar.ui.MainActivity
 import com.byagowi.persiancalendar.utils.getOrderedCalendarTypes
 import com.byagowi.persiancalendar.utils.getTodayJdn
 
@@ -17,9 +17,11 @@ class ConverterFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ) = FragmentConverterBinding.inflate(inflater, container, false).apply {
-        (activity as? MainActivity)?.setTitleAndSubtitle(
-            getString(R.string.date_converter), ""
-        )
+        with(appBar.toolbar) {
+            setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationOnClickListener { findNavController().navigateUp() }
+            setTitle(R.string.date_converter)
+        }
 
         calendarsView.toggle()
         calendarsView.hideMoreIcon()

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/preferences/PreferencesFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/preferences/PreferencesFragment.kt
@@ -23,6 +23,7 @@ class PreferencesFragment : Fragment() {
     ) = FragmentSettingsBinding.inflate(inflater, container, false).apply {
         with(appBar.toolbar) {
             setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationContentDescription(R.string.navigate_back_button_label)
             setNavigationOnClickListener { findNavController().navigateUp() }
             setTitle(R.string.settings)
         }

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/preferences/PreferencesFragment.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/preferences/PreferencesFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.findNavController
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.byagowi.persiancalendar.R
 import com.byagowi.persiancalendar.databinding.FragmentSettingsBinding
-import com.byagowi.persiancalendar.ui.MainActivity
 import com.byagowi.persiancalendar.ui.preferences.interfacecalendar.InterfaceCalendarFragment
 import com.byagowi.persiancalendar.ui.preferences.locationathan.LocationAthanFragment
 import com.byagowi.persiancalendar.ui.preferences.widgetnotification.WidgetNotificationFragment
@@ -21,7 +21,12 @@ class PreferencesFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ) = FragmentSettingsBinding.inflate(inflater, container, false).apply {
-        (activity as? MainActivity)?.setTitleAndSubtitle(getString(R.string.settings), "")
+        with(appBar.toolbar) {
+            setNavigationIcon(R.drawable.ic_arrow_back)
+            setNavigationOnClickListener { findNavController().navigateUp() }
+            setTitle(R.string.settings)
+        }
+
         val tabs = listOf(
             R.string.pref_header_interface_calendar to InterfaceCalendarFragment::class.java,
             R.string.pref_header_widget_location to WidgetNotificationFragment::class.java,

--- a/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/preferences/interfacecalendar/calendarsorder/RecyclerListAdapter.kt
+++ b/PersianCalendar/src/main/java/com/byagowi/persiancalendar/ui/preferences/interfacecalendar/calendarsorder/RecyclerListAdapter.kt
@@ -19,12 +19,12 @@ package com.byagowi.persiancalendar.ui.preferences.interfacecalendar.calendarsor
 import android.animation.ValueAnimator
 import android.graphics.Color
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.core.view.MotionEventCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.byagowi.persiancalendar.databinding.CalendarTypeItemBinding
-import com.byagowi.persiancalendar.ui.MainActivity
 import com.byagowi.persiancalendar.utils.layoutInflater
 import com.byagowi.persiancalendar.utils.logException
 
@@ -73,8 +73,7 @@ class RecyclerListAdapter(
         // Easter egg when all are swiped
         if (items.isEmpty()) {
             runCatching {
-                val view =
-                    (calendarPreferenceDialog.activity as? MainActivity)?.coordinator ?: return
+                val view = calendarPreferenceDialog.activity?.findViewById<View>(android.R.id.content) ?: return
                 ValueAnimator.ofFloat(0f, 360f).apply {
                     duration = 3000L
                     interpolator = AccelerateDecelerateInterpolator()

--- a/PersianCalendar/src/main/java/net/androgames/level/LevelFragment.java
+++ b/PersianCalendar/src/main/java/net/androgames/level/LevelFragment.java
@@ -49,9 +49,13 @@ public class LevelFragment extends Fragment {
         final MainActivity mainActivity = (MainActivity) getActivity();
         assert mainActivity != null;
         activity = mainActivity;
-        mainActivity.setTitleAndSubtitle(getString(R.string.level), "");
 
         final FragmentLevelBinding binding = FragmentLevelBinding.inflate(inflater, container, false);
+
+        binding.appBar.toolbar.setTitle(R.string.level);
+        binding.appBar.toolbar.setNavigationIcon(R.drawable.ic_arrow_back);
+        binding.appBar.toolbar.setNavigationOnClickListener(v -> NavHostFragment.findNavController(LevelFragment.this).navigateUp());
+
         provider = new OrientationProvider(activity, binding.levelView);
 
         binding.bottomAppbar.replaceMenu(R.menu.level_menu_buttons);

--- a/PersianCalendar/src/main/java/net/androgames/level/LevelFragment.java
+++ b/PersianCalendar/src/main/java/net/androgames/level/LevelFragment.java
@@ -54,6 +54,7 @@ public class LevelFragment extends Fragment {
 
         binding.appBar.toolbar.setTitle(R.string.level);
         binding.appBar.toolbar.setNavigationIcon(R.drawable.ic_arrow_back);
+        binding.appBar.toolbar.setNavigationContentDescription(R.string.navigate_back_button_label);
         binding.appBar.toolbar.setNavigationOnClickListener(v -> NavHostFragment.findNavController(LevelFragment.this).navigateUp());
 
         provider = new OrientationProvider(activity, binding.levelView);

--- a/PersianCalendar/src/main/res/drawable-ldrtl/ic_arrow_back.xml
+++ b/PersianCalendar/src/main/res/drawable-ldrtl/ic_arrow_back.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/PersianCalendar/src/main/res/drawable-ldrtl/ic_arrow_back.xml
+++ b/PersianCalendar/src/main/res/drawable-ldrtl/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#fff"
+        android:pathData="M12,4l-1.41,1.41L16.17,11H4v2h12.17l-5.58,5.59L12,20l8,-8z" />
+</vector>

--- a/PersianCalendar/src/main/res/drawable/ic_arrow_back.xml
+++ b/PersianCalendar/src/main/res/drawable/ic_arrow_back.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    >
+    android:viewportHeight="24">
     <path
         android:fillColor="#fff"
         android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />

--- a/PersianCalendar/src/main/res/drawable/ic_arrow_back.xml
+++ b/PersianCalendar/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="#fff"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/PersianCalendar/src/main/res/drawable/ic_burger_menu.xml
+++ b/PersianCalendar/src/main/res/drawable/ic_burger_menu.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/PersianCalendar/src/main/res/drawable/ic_burger_menu.xml
+++ b/PersianCalendar/src/main/res/drawable/ic_burger_menu.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#fff"
+        android:pathData="M3,18h18v-2L3,16v2zM3,13h18v-2L3,11v2zM3,6v2h18L21,6L3,6z" />
+</vector>

--- a/PersianCalendar/src/main/res/layout/activity_main.xml
+++ b/PersianCalendar/src/main/res/layout/activity_main.xml
@@ -6,43 +6,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".ui.MainActivity"
     tools:openDrawer="start">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <LinearLayout
-            android:id="@+id/app_main_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <com.google.android.material.appbar.AppBarLayout
-                android:id="@+id/appbarLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?attr/navigationBarColor"
-                app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-                <androidx.appcompat.widget.Toolbar
-                    android:id="@+id/toolbar"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:theme="?attr/toolbarTheme" />
-
-            </com.google.android.material.appbar.AppBarLayout>
-
-            <androidx.fragment.app.FragmentContainerView
-                android:id="@+id/nav_host_container"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-
-        </LinearLayout>
-
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+        android:layout_height="match_parent" />
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/navigation"

--- a/PersianCalendar/src/main/res/layout/app_bar.xml
+++ b/PersianCalendar/src/main/res/layout/app_bar.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/appbarLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/navigationBarColor">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="?attr/toolbarTheme" />
+</com.google.android.material.appbar.AppBarLayout>

--- a/PersianCalendar/src/main/res/layout/fragment_about.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_about.xml
@@ -11,6 +11,10 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <include
+            android:id="@+id/app_bar"
+            layout="@layout/app_bar" />
+
         <LinearLayout
             style="@style/AboutCard"
             android:background="?attr/colorCard"

--- a/PersianCalendar/src/main/res/layout/fragment_calendar.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_calendar.xml
@@ -4,11 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        android:id="@+id/app_bar"
+        layout="@layout/app_bar" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:scrollbars="none">
+        android:scrollbars="none"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/PersianCalendar/src/main/res/layout/fragment_compass.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_compass.xml
@@ -4,11 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        android:id="@+id/app_bar"
+        layout="@layout/app_bar" />
+
     <com.cepmuvakkit.times.view.QiblaCompassView
         android:id="@+id/compass_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.google.android.material.bottomappbar.BottomAppBar
         android:id="@+id/bottom_appbar"

--- a/PersianCalendar/src/main/res/layout/fragment_converter.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_converter.xml
@@ -5,10 +5,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        android:id="@+id/app_bar"
+        layout="@layout/app_bar" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/PersianCalendar/src/main/res/layout/fragment_device_info.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_device_info.xml
@@ -5,12 +5,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        android:id="@+id/app_bar"
+        layout="@layout/app_bar" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="55dp"
-        android:scrollbars="vertical" />
+        android:scrollbars="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"

--- a/PersianCalendar/src/main/res/layout/fragment_level.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_level.xml
@@ -4,11 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        android:id="@+id/app_bar"
+        layout="@layout/app_bar" />
+
     <net.androgames.level.view.LevelView
         android:id="@+id/level_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="80dp" />
+        android:layout_marginBottom="80dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.google.android.material.bottomappbar.BottomAppBar
         android:id="@+id/bottom_appbar"

--- a/PersianCalendar/src/main/res/layout/fragment_settings.xml
+++ b/PersianCalendar/src/main/res/layout/fragment_settings.xml
@@ -5,6 +5,10 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <include
+        android:id="@+id/app_bar"
+        layout="@layout/app_bar" />
+
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tab_layout"
         style="@style/TabLayoutColored"

--- a/PersianCalendar/src/main/res/values-ar/strings.xml
+++ b/PersianCalendar/src/main/res/values-ar/strings.xml
@@ -265,5 +265,7 @@
     <string name="age_widget_title">عنوان المصغر</string>
     <string name="select_date">اختيار التاريخ</string>
     <string name="age_widget_placeholder">%1$s يوم (~%2$s سنة، %3$s شهر، %4$s يوم)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-azb/strings.xml
+++ b/PersianCalendar/src/main/res/values-azb/strings.xml
@@ -230,5 +230,7 @@
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_placeholder">%1$s گۆن (~%2$s ایل، %3$s آی، %4$s گۆن)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-ckb/strings.xml
+++ b/PersianCalendar/src/main/res/values-ckb/strings.xml
@@ -229,5 +229,7 @@
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_placeholder">%1$s ڕۆژ (~%2$s ساڵ، %3$s مانگ، %4$s ڕۆژ)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-es/strings.xml
+++ b/PersianCalendar/src/main/res/values-es/strings.xml
@@ -261,5 +261,7 @@ The app needs this only once, however, if you move to a new location, accessing 
     <string name="select_date">Select date</string>
     <string name="age_widget_title">Widget title</string>
     <string name="age_widget_placeholder">%1$s days (~%2$s years, %3$s months, %4$s days)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-fa/strings.xml
+++ b/PersianCalendar/src/main/res/values-fa/strings.xml
@@ -231,7 +231,7 @@
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="age_widget_placeholder">%1$s روز (~%2$s سال، %3$s ماه، %4$s روز)</string>
-    <string name="menu_button_label">Menu</string>
-    <string name="navigate_back_button_label">Back</string>
+    <string name="menu_button_label">منو</string>
+    <string name="navigate_back_button_label">بازگشت</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-fa/strings.xml
+++ b/PersianCalendar/src/main/res/values-fa/strings.xml
@@ -231,5 +231,7 @@
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="age_widget_placeholder">%1$s روز (~%2$s سال، %3$s ماه، %4$s روز)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-glk/strings.xml
+++ b/PersianCalendar/src/main/res/values-glk/strings.xml
@@ -230,5 +230,7 @@
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_placeholder">%1$s رۊز (~%2$s سال، %3$s ما، %4$s رۊز)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-ja/strings.xml
+++ b/PersianCalendar/src/main/res/values-ja/strings.xml
@@ -232,5 +232,7 @@ The app needs this only once, however, if you move to a new location, accessing 
     <string name="age_widget_title">Widget title</string>
     <string name="select_date">Select date</string>
     <string name="age_widget_placeholder">%1$s days (~%2$s years, %3$s months, %4$s days)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-ps/strings.xml
+++ b/PersianCalendar/src/main/res/values-ps/strings.xml
@@ -231,5 +231,7 @@
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="age_widget_placeholder">%1$s روز (~%2$s سال، %3$s ماه، %4$s روز)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values-ur/strings.xml
+++ b/PersianCalendar/src/main/res/values-ur/strings.xml
@@ -229,5 +229,7 @@
     <string name="age_widget_title">عنوان ویجت</string>
     <string name="select_date">انتخاب تاریخ</string>
     <string name="age_widget_placeholder">%1$s روز (~%2$s سال، %3$s ماه، %4$s روز)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>

--- a/PersianCalendar/src/main/res/values/strings.xml
+++ b/PersianCalendar/src/main/res/values/strings.xml
@@ -328,5 +328,7 @@ The app needs this only once, however, if you move to a new location, accessing 
     <string name="select_date">Select date</string>
     <string name="age_widget_title">Widget title</string>
     <string name="age_widget_placeholder">%1$s days (~%2$s years, %3$s months, %4$s days)</string>
+    <string name="menu_button_label">Menu</string>
+    <string name="navigate_back_button_label">Back</string>
 
 </resources>


### PR DESCRIPTION
- Removed shared toolbar of activity from child fragments to reduce dependency to other classes.
- Now each fragment can have its own toolbar and manage.
- Fixes #628
-----------------

- CalendarFragment that can open NavigationDrawer works with a callback interface and pass events to its parent.
- `ic_arrow_back` has provided separately for RTL conditions.
- Consider all navigation's a11y description